### PR TITLE
Fix dispatching several actions ONCE.

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ export default store => {
 
           //remove the delayed action
           if (when.type === ONCE) {
-            waiting.splice(index, 1);
+            delete waiting[index];
           }
 
           //dispatch the delayed action

--- a/test/index.js
+++ b/test/index.js
@@ -69,7 +69,7 @@ describe('redux-when', () => {
               ACTION_FOO
           ]);
       });
-
+      
       it('should not dispatch delayed action when the condition evaluates to false', () => {
 
         const store = createStore();
@@ -104,6 +104,29 @@ describe('redux-when', () => {
         ]);
 
       });
+      
+      it('should dispatch several delayed actions ONCE when evaluated as true', () => {
+          const store = createStore();
+          const condition = sinon.stub();
+          condition.withArgs({}, ACTION_FOOBAR).returns(true);
+          const actionCreator1 = sinon.stub().returns(ACTION_FOO);
+          const actionCreator2 = sinon.stub().returns(ACTION_BAR);
+
+          store.dispatch(once(condition, actionCreator1));
+          store.dispatch(once(condition, actionCreator2));
+          store.dispatch(ACTION_FOOBAR);
+          store.dispatch(ACTION_FOOBAR);
+
+          expect(actionCreator1).to.be.calledOnce;
+          expect(actionCreator2).to.be.calledOnce;
+          expect(store.getActions()).to.be.deep.equal([
+              ACTION_FOOBAR,
+              ACTION_FOO,
+              ACTION_BAR,
+              ACTION_FOOBAR
+          ]);
+      });
+
 
     });
 


### PR DESCRIPTION
Dispatching several actions once has problem. Every second sequential ONCE action is skipped.

Problem is described in accepted answer [here](https://stackoverflow.com/questions/24812930/how-to-remove-element-from-array-in-foreach-loop).

Calling splice within forEach reenumerates array, so action with true condition will be skipped if it was added after ONCE action with true condition.

 Fixes #7